### PR TITLE
feat/cli interface

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Casimiro Ferreira
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/ovos_gguf_embeddings/__init__.py
+++ b/ovos_gguf_embeddings/__init__.py
@@ -39,6 +39,8 @@ class GGUFTextEmbeddingsStore(TextEmbeddingsStore):
             db = f"{db_path}/{model.split('/')[-1].split('.')[0]}"
 
         if isinstance(db, str):
+            if "/" not in db:  # use xdg path
+                db = f"{get_xdg_cache_save_path("chromadb")}/{db}"
             LOG.info(f"Using chromadb as text embeddings store: {db}")
             db = ChromaEmbeddingsDB(db)
 

--- a/ovos_gguf_embeddings/cli.py
+++ b/ovos_gguf_embeddings/cli.py
@@ -1,0 +1,108 @@
+import click
+from quebra_frases import sentence_tokenize, paragraph_tokenize
+from ovos_gguf_embeddings import GGUFTextEmbeddingsStore
+
+
+@click.group()
+def cli():
+    """CLI for interacting with the GGUF Text Embeddings Store."""
+    pass
+
+
+@click.command()
+@click.option('--database', prompt='Path to the ChromaDB database',
+              help='Path to the ChromaDB database where the embeddings are stored.')
+@click.option('--model', default='paraphrase-multilingual-minilm-l12-v2',
+              help='Model name or URL used for generating embeddings. Defaults to "paraphrase-multilingual-minilm-l12-v2".')
+@click.option('--top-k', default=5, help='Number of top results to return. Defaults to 5.')
+@click.argument('query')
+def query_document(query, database, model, top_k):
+    """
+    Query the embeddings store to find similar documents to the given query.
+
+    QUERY: The query string used to search for similar documents.
+
+    DATABASE: Path to the ChromaDB database where the embeddings are stored. Can be a full path or a simple string.
+              If a simple string is provided, it will be saved in the XDG cache directory (~/.cache/chromadb/{database}).
+
+    MODEL: Name or URL of the model used for generating embeddings. (Defaults to 'paraphrase-multilingual-minilm-l12-v2')
+
+    TOP-K: Number of top results to return. (Defaults to 5)
+    """
+    gguf = GGUFTextEmbeddingsStore(db=database, model=model)
+    docs = gguf.query(query, top_k=top_k)
+    click.echo(f"Query results for '{query}':")
+    for doc in docs:
+        click.echo(f"Document: {doc[0]}, Distance: {doc[1]}")
+
+
+@click.command()
+@click.argument('document')
+@click.option('--database', prompt='Path to the ChromaDB database',
+              help='ChromaDB database where the embeddings are stored.')
+@click.option('--model', default='paraphrase-multilingual-minilm-l12-v2',
+              help='Model name or URL used for generating embeddings. Defaults to "paraphrase-multilingual-minilm-l12-v2".')
+@click.option('--from-file', is_flag=True, help='Indicates if the document argument is a file path.')
+@click.option('--use-sentences', is_flag=True,
+              help='Indicates if the document should be tokenized into sentences; otherwise, it is split into paragraphs.')
+def add_document(document, database, model, from_file, use_sentences):
+    """
+    Add a document to the embeddings store.
+
+    DOCUMENT: The document string or file path to be added to the store.
+
+    FROM-FILE: Flag indicating whether the DOCUMENT argument is a file path. If set, the file is read and processed.
+
+    USE-SENTENCES: Flag indicating whether to tokenize the document into sentences. If not set, the document is split into paragraphs.
+
+    DATABASE: Path to the ChromaDB database where the embeddings are stored. Can be a full path or a simple string.
+              If a simple string is provided, it will be saved in the XDG cache directory (~/.cache/chromadb/{database}).
+
+    MODEL: Name or URL of the model used for generating embeddings. (Defaults to 'paraphrase-multilingual-minilm-l12-v2')
+    """
+    gguf = GGUFTextEmbeddingsStore(db=database, model=model)
+
+    if from_file:
+        with open(document, "r") as f:
+            document = f.read()
+        if use_sentences:
+            for p in paragraph_tokenize(document):
+                for s in sentence_tokenize(p):
+                    gguf.add_document(s)
+        else:
+            for p in paragraph_tokenize(document):
+                gguf.add_document(p)
+    else:
+        gguf.add_document(document)
+
+    click.echo(f"Document added: '{document[:30]}...'")  # Show only the first 30 chars for brevity
+
+
+@click.command()
+@click.argument('document')
+@click.option('--database', prompt='Path to the ChromaDB database',
+              help='ChromaDB database where the embeddings are stored.')
+@click.option('--model', default='paraphrase-multilingual-minilm-l12-v2',
+              help='Model name or URL used for generating embeddings. Defaults to "paraphrase-multilingual-minilm-l12-v2".')
+def delete_document(document, database, model):
+    """
+    Delete a document from the embeddings store.
+
+    DOCUMENT: The document string to be deleted from the store.
+
+    DATABASE: Path to the ChromaDB database where the embeddings are stored. Can be a full path or a simple string.
+              If a simple string is provided, it will be saved in the XDG cache directory (~/.cache/chromadb/{database}).
+
+    MODEL: Name or URL of the model used for generating embeddings. (Defaults to 'paraphrase-multilingual-minilm-l12-v2')
+    """
+    gguf = GGUFTextEmbeddingsStore(db=database, model=model)
+    gguf.delete_document(document)
+    click.echo(f"Document deleted: '{document[:30]}...'")  # Show only the first 30 chars for brevity
+
+
+cli.add_command(query_document)
+cli.add_command(add_document)
+cli.add_command(delete_document)
+
+if __name__ == '__main__':
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -55,11 +55,16 @@ setup(
     url='https://github.com/TigreGotico/ovos-gguf-embeddings-plugin',
     author='jarbasai',
     author_email='jarbasai@mailfence.com',
-    license='MIT',
+    license='Apache 2.0',
     packages=['ovos_gguf_embeddings'],
     zip_safe=True,
     keywords='OVOS openvoiceos plugin gguf recognition',
-    entry_points={'opm.embeddings.text': PLUGIN_ENTRY_POINT},
+    entry_points={'opm.embeddings.text': PLUGIN_ENTRY_POINT,
+
+                  'console_scripts': [
+                      'ovos-gguf-embeddings=ovos_gguf_embeddings.cli:cli'
+                  ]
+                  },
     install_requires=required("requirements.txt"),
     long_description=long_desc,
     long_description_content_type='text/markdown'


### PR DESCRIPTION
add a cli interface for managing text embeddings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line interface (CLI) for managing the GGUF Text Embeddings Store, allowing users to query, add, and delete documents.
	- Updated licensing to Apache 2.0, providing clear terms for software use and distribution.

- **Improvements**
	- Enhanced database initialization logic to ensure proper path formatting for the `db` parameter.

- **Chores**
	- Added a new `LICENSE` file outlining the terms of the Apache License, Version 2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->